### PR TITLE
Fix: Use instance variable @current_prompt instead of local variable

### DIFF
--- a/lib/raix/prompt_declarations.rb
+++ b/lib/raix/prompt_declarations.rb
@@ -83,7 +83,7 @@ module Raix
         params = @current_prompt.params.merge(params)
 
         # set the stream if necessary
-        self.stream = instance_exec(&current_prompt.stream) if current_prompt.stream.present?
+        self.stream = instance_exec(&@current_prompt.stream) if @current_prompt.stream.present?
 
         super(params:, raw:).then do |response|
           transcript << { assistant: response }


### PR DESCRIPTION
## Problem
In the `chat_completion` method of the `PromptDeclarations` module, there was an attempt to access `current_prompt` as a local variable, but it's an instance variable.

## Fix
Changed `current_prompt` to `@current_prompt` in the following line:
```ruby
self.stream = instance_exec(&@current_prompt.stream) if @current_prompt.stream.present?