### PR TITLE
Add an example config for OpenRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,18 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
     $ gem install raix
 
+If you are using the default OpenRouter API, Raix expects `Raix.configuration.openrouter_client` to initialized with the OpenRouter API client instance.
+
+You can add an initializer to your application's `config/initializers` directory:
+
+```ruby
+  # config/initializers/raix.rb
+  Raix.configure do |config|
+    config.openrouter_client = OpenRouter::Client.new
+  end
+```
+
+You will also need to configure the OpenRouter API access token as per the instructions here: https://github.com/OlympiaAI/open_router?tab=readme-ov-file#quickstart
 
 ## Development
 


### PR DESCRIPTION
Closes #2 

## Description

This PR updates the Installation section of the README to include some basic configuration that allows the simple example presented to run successfully.

<img width="1055" alt="image" src="https://github.com/user-attachments/assets/32e318bc-1ddc-4eea-a94c-0e671a8716a3">
