### PR TITLE
Update raix.gemspec to include openai

### DIFF
--- a/raix.gemspec
+++ b/raix.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport", ">= 6.0"
   spec.add_dependency "open_router", "~> 0.2"
+  spec.add_dependency "ruby-openai"
 end


### PR DESCRIPTION
Gem crashes on load if openai is not available.

[require "openai"
](https://github.com/OlympiaAI/raix-rails/blob/c3f21ece8921bef080199073aea30bf504e74689/lib/raix/chat_completion.rb#L6C1-L7C1)
