### PR TITLE
Clarify documentation of openai param in chat_completion

### DIFF
--- a/lib/raix/chat_completion.rb
+++ b/lib/raix/chat_completion.rb
@@ -43,12 +43,12 @@ module Raix
     # @param params [Hash] The parameters for chat completion.
     # @option loop [Boolean] :loop (false) Whether to loop the chat completion after function calls.
     # @option params [Boolean] :json (false) Whether to return the parse the response as a JSON object. Will search for <json> tags in the response first, then fall back to the default JSON parsing of the entire response.
-    # @option params [Boolean] :openai (false) Whether to use OpenAI's API instead of OpenRouter's.
+    # @option params [String] :openai (nil) If non-nil, use OpenAI with the model specified in this param.
     # @option params [Boolean] :raw (false) Whether to return the raw response or dig the text content.
     # @option params [Array] :messages (nil) An array of messages to use instead of the transcript.
     # @option tools [Array|false] :available_tools (nil) Tools to pass to the LLM. Ignored if nil (default). If false, no tools are passed. If an array, only declared tools in the array are passed.
     # @return [String|Hash] The completed chat response.
-    def chat_completion(params: {}, loop: false, json: false, raw: false, openai: false, save_response: true, messages: nil, available_tools: nil)
+    def chat_completion(params: {}, loop: false, json: false, raw: false, openai: nil, save_response: true, messages: nil, available_tools: nil)
       # set params to default values if not provided
       params[:cache_at] ||= cache_at.presence
       params[:frequency_penalty] ||= frequency_penalty.presence


### PR DESCRIPTION
`openai` is a boolean, not a `model` (and it's always `true` here).

(also, Hi @obie 👋, always happy to bump into you doing awesome stuff.)