### PR TITLE
Tweak how response format is sent so it works when passed a ResponseFormat

### DIFF
--- a/lib/raix/chat_completion.rb
+++ b/lib/raix/chat_completion.rb
@@ -68,13 +68,17 @@ module Raix
       params[:top_logprobs] ||= top_logprobs.presence
       params[:top_p] ||= top_p.presence
 
+      json = true if params[:response_format].is_a?(Raix::ResponseFormat)
+
       if json
         unless openai
           params[:provider] ||= {}
           params[:provider][:require_parameters] = true
         end
-        params[:response_format] ||= {}
-        params[:response_format][:type] = "json_object"
+        if params[:response_format].blank?
+          params[:response_format] ||= {}
+          params[:response_format][:type] = "json_object"
+        end
       end
 
       # used by FunctionDispatch


### PR DESCRIPTION
I messed with this until it works. You probably want #13 along with it to generate more consistently according to the docs, and there are still readme fixes necessary (passing `params: { response_format: format }` to chat_completion) but this is actually returning results correctly.