### PR TITLE
Allow filtering of tools with the :tool argument in chat_completion

### DIFF
--- a/lib/raix/function_dispatch.rb
+++ b/lib/raix/function_dispatch.rb
@@ -94,10 +94,7 @@ module Raix
     end
 
     def chat_completion(**chat_completion_args)
-      raise "No functions defined" if self.class.functions.blank?
-
       self.chat_completion_args = chat_completion_args
-
       super
     end
 
@@ -109,6 +106,8 @@ module Raix
     end
 
     def tools
+      return [] unless self.class.functions
+
       self.class.functions.map { |function| { type: "function", function: } }
     end
   end

--- a/spec/vcr/Raix_FunctionDispatch/supports_filtering_tools_with_the_tools_parameter.yml
+++ b/spec/vcr/Raix_FunctionDispatch/supports_filtering_tools_with_the_tools_parameter.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://openrouter.ai/api/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":"What is the weather in Zipolite,
+        Oaxaca?"},{"role":"user","content":"Call the check_weather function."}],"model":"meta-llama/llama-3-8b-instruct:free","max_tokens":1000,"seed":9999,"temperature":0.0}'
+    headers:
+      Authorization:
+      - Bearer REDACTED
+      Content-Type:
+      - application/json
+      X-Title:
+      - OpenRouter Ruby Client
+      Http-Referer:
+      - https://github.com/OlympiaAI/open_router
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Thu, 24 Apr 2025 18:11:37 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Clerk-Auth-Message:
+      - Invalid JWT form. A JWT consists of three parts separated by dots. (reason=token-invalid,
+        token-carrier=header)
+      X-Clerk-Auth-Reason:
+      - token-invalid
+      X-Clerk-Auth-Status:
+      - signed-out
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 935790707dd47c93-EWR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":{"message":"No endpoints found for meta-llama/llama-3-8b-instruct:free.","code":404},"user_id":"user_2eKz796ioaKIH2YpbgwvQVnUCGx"}'
+  recorded_at: Thu, 24 Apr 2025 18:11:37 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
This PR adds support to a `tools` keyword argument on `chat_completion`.

Imagine this class:
```
class MyClass
  include Raix::ChatCompletion
  include Raix::FunctionDispatch

  function :tool_1 ...
  function :tool_2 ...
  function :tool_3 ...
end
```

This change allows calling `my_class.chat_completion(tools: [:tool_1, :tool_2])`, and only these tools will be passed to the LLM suring that completion.

- Passing `tools: false` will disable the tools for that request.
- Passing no `tools` argument will include all tools (current behaviour)
- Passing a function that has not been declared raises `UndeclaredToolError`.
