### PR TITLE
Add required/optional parameter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.8.6] - 2025-05-19
+- add `required` and `optional` flags for parameters in `function` declarations
+
 ## [0.8.5] - 2025-05-08
 - renamed `tools` argument to `chat_completion` to `available_tools` to prevent shadowing the existing tool attribute (potentially breaking change to enhancement introduced in 0.8.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    raix (0.8.5)
+    raix (0.8.6)
       activesupport (>= 6.0)
       faraday-retry (~> 2.0)
       open_router (~> 0.2)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ class WhatIsTheWeather
   include Raix::ChatCompletion
   include Raix::FunctionDispatch
 
-  function :check_weather, "Check the weather for a location", location: { type: "string" } do |arguments|
+  function :check_weather,
+           "Check the weather for a location",
+           location: { type: "string", required: true } do |arguments|
     "The weather in #{arguments[:location]} is hot and sunny"
   end
 end
@@ -131,6 +133,8 @@ RSpec.describe WhatIsTheWeather do
   end
 end
 ```
+
+Parameters are optional by default. Mark them as required with `required: true` or explicitly optional with `optional: true`.
 
 Note that for security reasons, dispatching functions only works with functions implemented using `Raix::FunctionDispatch#function` or directly on the class.
 

--- a/lib/raix/function_dispatch.rb
+++ b/lib/raix/function_dispatch.rb
@@ -46,11 +46,21 @@ module Raix
       def function(name, description = nil, **parameters, &block)
         @functions ||= []
         @functions << begin
-          { name:, parameters: { type: "object", properties: {} } }.tap do |definition|
+          {
+            name:,
+            parameters: { type: "object", properties: {}, required: [] }
+          }.tap do |definition|
             definition[:description] = description if description.present?
-            parameters.map do |key, value|
+            parameters.each do |key, value|
+              value = value.dup
+              required = value.delete(:required)
+              optional = value.delete(:optional)
               definition[:parameters][:properties][key] = value
+              if required || optional == false
+                definition[:parameters][:required] << key
+              end
             end
+            definition[:parameters].delete(:required) if definition[:parameters][:required].empty?
           end
         end
 

--- a/lib/raix/version.rb
+++ b/lib/raix/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Raix
-  VERSION = "0.8.5"
+  VERSION = "0.8.6"
 end

--- a/spec/raix/function_dispatch_spec.rb
+++ b/spec/raix/function_dispatch_spec.rb
@@ -32,6 +32,18 @@ class MultipleToolCalls
   end
 end
 
+class SearchForFile
+  include Raix::ChatCompletion
+  include Raix::FunctionDispatch
+
+  function :search_for_file,
+           "Search for a file in the project",
+           glob_pattern: { type: "string", required: true },
+           path: { type: "string", optional: true } do |_arguments|
+    "found"
+  end
+end
+
 RSpec.describe Raix::FunctionDispatch, :vcr do
   let(:callback) { double("callback") }
 
@@ -62,6 +74,13 @@ RSpec.describe Raix::FunctionDispatch, :vcr do
     end
 
     weather.chat_completion(available_tools: false)
+  end
+
+  it "tracks required and optional parameters" do
+    params = SearchForFile.new.tools.first[:function][:parameters]
+    expect(params[:required]).to eq([:glob_pattern])
+    expect(params[:properties].keys).to include(:path)
+    expect(params[:required]).not_to include(:path)
   end
 
   # This simulates a middleman on the network that rewrites the function name to anything else


### PR DESCRIPTION
## Summary
- allow `function` definitions to mark parameters as required or optional
- document required/optional usage in README
- bump version to 0.8.6 and update changelog
- test that required/optional flags are reflected in tools

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*