### PR TITLE
Allow checking configuration for api client

### DIFF
--- a/lib/raix.rb
+++ b/lib/raix.rb
@@ -44,6 +44,10 @@ module Raix
       self.max_tokens = DEFAULT_MAX_TOKENS
       self.model = DEFAULT_MODEL
     end
+
+    def client?
+      !!(openrouter_client || openai_client)
+    end
   end
 
   class << self

--- a/spec/raix_spec.rb
+++ b/spec/raix_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Raix::Configuration do
+  describe "#client?" do
+    context "with an openrouter_client" do
+      it "returns true" do
+        configuration = Raix::Configuration.new
+        configuration.openrouter_client = OpenRouter::Client.new
+        expect(configuration.client?).to eq true
+      end
+    end
+
+    context "with an openai_client" do
+      it "returns true" do
+        configuration = Raix::Configuration.new
+        configuration.openai_client = OpenAI::Client.new
+        expect(configuration.client?).to eq true
+      end
+    end
+
+    context "without an api client" do
+      it "returns false" do
+        configuration = Raix::Configuration.new
+        expect(configuration.client?).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Over on Roast I was interested in adding some logic to skip creating an api client when one has been provided via an initializer so I came here to see what that would look like. Turns out it's pretty easy so I thought I'd see about making this change up here. 