### PR TITLE
Class level configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,6 +703,21 @@ You can add an initializer to your application's `config/initializers` directory
 
 You will also need to configure the OpenRouter API access token as per the instructions here: https://github.com/OlympiaAI/open_router?tab=readme-ov-file#quickstart
 
+### Global vs class level configuration
+
+You can either configure Raix globally or at the class level. The global configuration is set in the initializer as shown above. You can however also override all configuration options of the `Configuration` class on the class level with the
+same syntax:
+
+```ruby
+class MyClass
+  include Raix::ChatCompletion
+
+  configure do |config|
+    config.openrouter_client = OpenRouter::Client.new # with my special options
+  end
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/raix.rb
+++ b/lib/raix.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "raix/version"
+require_relative "raix/configuration"
 require_relative "raix/chat_completion"
 require_relative "raix/function_dispatch"
 require_relative "raix/prompt_declarations"
@@ -10,42 +11,6 @@ require_relative "raix/mcp"
 
 # The Raix module provides configuration options for the Raix gem.
 module Raix
-  # The Configuration class holds the configuration options for the Raix gem.
-  class Configuration
-    # The temperature option determines the randomness of the generated text.
-    # Higher values result in more random output.
-    attr_accessor :temperature
-
-    # The max_tokens option determines the maximum number of tokens to generate.
-    attr_accessor :max_tokens
-
-    # The max_completion_tokens option determines the maximum number of tokens to generate.
-    attr_accessor :max_completion_tokens
-
-    # The model option determines the model to use for text generation. This option
-    # is normally set in each class that includes the ChatCompletion module.
-    attr_accessor :model
-
-    # The openrouter_client option determines the default client to use for communicatio.
-    attr_accessor :openrouter_client
-
-    # The openai_client option determines the OpenAI client to use for communication.
-    attr_accessor :openai_client
-
-    DEFAULT_MAX_TOKENS = 1000
-    DEFAULT_MAX_COMPLETION_TOKENS = 16_384
-    DEFAULT_MODEL = "meta-llama/llama-3-8b-instruct:free"
-    DEFAULT_TEMPERATURE = 0.0
-
-    # Initializes a new instance of the Configuration class with default values.
-    def initialize
-      self.temperature = DEFAULT_TEMPERATURE
-      self.max_completion_tokens = DEFAULT_MAX_COMPLETION_TOKENS
-      self.max_tokens = DEFAULT_MAX_TOKENS
-      self.model = DEFAULT_MODEL
-    end
-  end
-
   class << self
     attr_writer :configuration
   end

--- a/lib/raix/configuration.rb
+++ b/lib/raix/configuration.rb
@@ -5,23 +5,36 @@ module Raix
   class Configuration
     # The temperature option determines the randomness of the generated text.
     # Higher values result in more random output.
-    attr_accessor :temperature
+    def temperature
+      get_with_fallback(:temperature)
+    end
+    attr_writer :temperature, :max_tokens, :max_completion_tokens, :model, :openrouter_client, :openai_client
 
     # The max_tokens option determines the maximum number of tokens to generate.
-    attr_accessor :max_tokens
+    def max_tokens
+      get_with_fallback(:max_tokens)
+    end
 
     # The max_completion_tokens option determines the maximum number of tokens to generate.
-    attr_accessor :max_completion_tokens
+    def max_completion_tokens
+      get_with_fallback(:max_completion_tokens)
+    end
 
     # The model option determines the model to use for text generation. This option
     # is normally set in each class that includes the ChatCompletion module.
-    attr_accessor :model
+    def model
+      get_with_fallback(:model)
+    end
 
-    # The openrouter_client option determines the default client to use for communicatio.
-    attr_accessor :openrouter_client
+    # The openrouter_client option determines the default client to use for communication.
+    def openrouter_client
+      get_with_fallback(:openrouter_client)
+    end
 
     # The openai_client option determines the OpenAI client to use for communication.
-    attr_accessor :openai_client
+    def openai_client
+      get_with_fallback(:openai_client)
+    end
 
     DEFAULT_MAX_TOKENS = 1000
     DEFAULT_MAX_COMPLETION_TOKENS = 16_384
@@ -29,11 +42,24 @@ module Raix
     DEFAULT_TEMPERATURE = 0.0
 
     # Initializes a new instance of the Configuration class with default values.
-    def initialize
+    def initialize(fallback: nil)
       self.temperature = DEFAULT_TEMPERATURE
       self.max_completion_tokens = DEFAULT_MAX_COMPLETION_TOKENS
       self.max_tokens = DEFAULT_MAX_TOKENS
       self.model = DEFAULT_MODEL
+      self.fallback = fallback
+    end
+
+    private
+
+    attr_accessor :fallback
+
+    def get_with_fallback(method)
+      value = instance_variable_get("@#{method}")
+      return value if value
+      return unless fallback
+
+      fallback.public_send(method)
     end
   end
 end

--- a/lib/raix/configuration.rb
+++ b/lib/raix/configuration.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Raix
+  # The Configuration class holds the configuration options for the Raix gem.
+  class Configuration
+    # The temperature option determines the randomness of the generated text.
+    # Higher values result in more random output.
+    attr_accessor :temperature
+
+    # The max_tokens option determines the maximum number of tokens to generate.
+    attr_accessor :max_tokens
+
+    # The max_completion_tokens option determines the maximum number of tokens to generate.
+    attr_accessor :max_completion_tokens
+
+    # The model option determines the model to use for text generation. This option
+    # is normally set in each class that includes the ChatCompletion module.
+    attr_accessor :model
+
+    # The openrouter_client option determines the default client to use for communicatio.
+    attr_accessor :openrouter_client
+
+    # The openai_client option determines the OpenAI client to use for communication.
+    attr_accessor :openai_client
+
+    DEFAULT_MAX_TOKENS = 1000
+    DEFAULT_MAX_COMPLETION_TOKENS = 16_384
+    DEFAULT_MODEL = "meta-llama/llama-3-8b-instruct:free"
+    DEFAULT_TEMPERATURE = 0.0
+
+    # Initializes a new instance of the Configuration class with default values.
+    def initialize
+      self.temperature = DEFAULT_TEMPERATURE
+      self.max_completion_tokens = DEFAULT_MAX_COMPLETION_TOKENS
+      self.max_tokens = DEFAULT_MAX_TOKENS
+      self.model = DEFAULT_MODEL
+    end
+  end
+end

--- a/lib/raix/predicate.rb
+++ b/lib/raix/predicate.rb
@@ -26,11 +26,8 @@ module Raix
   #   question = Question.new
   #   question.ask("Is Ruby a programming language?")
   module Predicate
+    extend ActiveSupport::Concern
     include ChatCompletion
-
-    def self.included(base)
-      base.extend(ClassMethods)
-    end
 
     def ask(question, openai: false)
       raise "Please define a yes and/or no block" if self.class.yes_block.nil? && self.class.no_block.nil?

--- a/spec/raix/chat_completion_spec.rb
+++ b/spec/raix/chat_completion_spec.rb
@@ -10,6 +10,18 @@ class MeaningOfLife
   end
 end
 
+class TestClassLevelConfiguration
+  include Raix::ChatCompletion
+
+  configure do |config|
+    config.model = "drama-llama"
+  end
+
+  def initialize
+    transcript << { user: "What is the meaning of life?" }
+  end
+end
+
 RSpec.describe MeaningOfLife, :vcr do
   subject { described_class.new }
 
@@ -44,5 +56,15 @@ RSpec.describe MeaningOfLife, :vcr do
       expect(response.dig("usage", "completion_tokens_details", "accepted_prediction_tokens")).to be > 0
       expect(response.dig("usage", "completion_tokens_details", "rejected_prediction_tokens")).to be > 0
     end
+  end
+end
+
+
+RSpec.describe TestClassLevelConfiguration do
+  it 'calls the open router gem with the correct model' do
+    expect(Raix.configuration.openrouter_client).to receive(:complete) do |_messages, params|
+      expect(params[:model]).to eq("drama-llama")
+    end.and_return({'choices' =>  [{'message' =>  {'content' => "The meaning of life is to find your own meaning."}}]})
+    subject.chat_completion
   end
 end


### PR DESCRIPTION
This adds a class level configuration for Raix, allowing users to e.g. set the client per class. This is useful if you want to use different API keys for different parts of your application.

The code is a bit verbose and the `Raix::Configuration` class doesn't look that nice anymore, but I felt that this would be the better choice over doing some meta programming to first check the class level config and the fall back to the global config. Obviously that is a debatable.

Not sure if everything is in the right place either and how much to test this.

Closes #23