### PR TITLE
Add MCP type coercion and image support

### DIFF
--- a/lib/raix/mcp.rb
+++ b/lib/raix/mcp.rb
@@ -235,7 +235,7 @@ module Raix
           coerced_object = {}
           schema["properties"].each do |prop_key, prop_schema|
             prop_value = object_value[prop_key] || object_value[prop_key.to_sym]
-            coerced_object[prop_key] = coerce_value(prop_value, prop_schema) if prop_value
+            coerced_object[prop_key] = coerce_value(prop_value, prop_schema) unless prop_value.nil?
           end
 
           # Include any additional properties not in the schema

--- a/lib/raix/mcp.rb
+++ b/lib/raix/mcp.rb
@@ -174,7 +174,11 @@ module Raix
 
       coerced = {}
       schema["properties"].each do |key, prop_schema|
-        value = arguments[key] || arguments[key.to_sym]
+        value = if arguments.key?(key)
+                  arguments[key]
+                elsif arguments.key?(key.to_sym)
+                  arguments[key.to_sym]
+                end
         next if value.nil?
 
         coerced[key] = coerce_value(value, prop_schema)

--- a/spec/raix/mcp/stdio_client_spec.rb
+++ b/spec/raix/mcp/stdio_client_spec.rb
@@ -80,11 +80,14 @@ RSpec.describe Raix::MCP::StdioClient do
       expect(JSON.parse(result)).to include("processed" => true)
     end
 
-    it "raises NotImplementedError for non-text content" do
-      # The test server should have a tool that returns non-text content
-      expect do
-        client.call_tool("binary_data")
-      end.to raise_error(NotImplementedError, "Only text is supported")
+    it "handles image content by returning structured JSON" do
+      result = client.call_tool("binary_data")
+      expect(result).to be_a(String)
+
+      parsed = JSON.parse(result)
+      expect(parsed["type"]).to eq("image")
+      expect(parsed["data"]).to eq("base64encodeddata")
+      expect(parsed["mime_type"]).to eq("image/png")
     end
 
     it "raises ProtocolError for invalid tool names" do

--- a/spec/raix/mcp_spec.rb
+++ b/spec/raix/mcp_spec.rb
@@ -1,0 +1,69 @@
+describe "type coercion" do
+  let(:test_class) do
+    Class.new do
+      include Raix::ChatCompletion
+      include Raix::MCP
+
+      def self.name
+        "TestMcpTypeCoercion"
+      end
+    end
+  end
+
+  it "coerces string numbers to numeric types based on schema" do
+    instance = test_class.new
+
+    # Test integer coercion
+    schema = {
+      "properties" => {
+        "x" => { "type" => "integer" },
+        "y" => { "type" => "number" },
+        "enabled" => { "type" => "boolean" },
+        "items" => { "type" => "array" },
+        "data" => { "type" => "object" }
+      }
+    }
+
+    arguments = {
+      "x" => "100",
+      "y" => "50.5",
+      "enabled" => "true",
+      "items" => "[1, 2, 3]",
+      "data" => '{"key": "value"}'
+    }
+
+    result = instance.send(:coerce_arguments, arguments, schema)
+
+    expect(result["x"]).to eq(100)
+    expect(result["x"]).to be_a(Integer)
+
+    expect(result["y"]).to eq(50.5)
+    expect(result["y"]).to be_a(Float)
+
+    expect(result["enabled"]).to eq(true)
+    expect(result["enabled"]).to be_a(TrueClass)
+
+    expect(result["items"]).to eq([1, 2, 3])
+    expect(result["items"]).to be_a(Array)
+
+    expect(result["data"]).to eq({ "key" => "value" })
+    expect(result["data"]).to be_a(Hash)
+  end
+
+  it "preserves non-string values" do
+    instance = test_class.new
+
+    schema = {
+      "properties" => {
+        "x" => { "type" => "integer" },
+        "y" => { "type" => "number" }
+      }
+    }
+
+    arguments = { "x" => 100, "y" => 50.5 }
+    result = instance.send(:coerce_arguments, arguments, schema)
+
+    expect(result["x"]).to eq(100)
+    expect(result["y"]).to eq(50.5)
+  end
+end

--- a/spec/raix/mcp_spec.rb
+++ b/spec/raix/mcp_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe "MCP type coercion" do
 
     result = instance.send(:coerce_arguments, arguments, schema)
 
-    expect(result["tags"]).to eq(["tag1", "tag2", "tag3"])
+    expect(result["tags"]).to eq(%w[tag1 tag2 tag3])
     expect(result["config"]["enabled"]).to eq(true)
     expect(result["config"]["extra"]).to eq("value") # preserves extra properties
   end
@@ -268,7 +268,7 @@ RSpec.describe "MCP type coercion" do
     }
 
     arguments = {
-      value: "100"  # symbol key
+      value: "100" # symbol key
     }
 
     result = instance.send(:coerce_arguments, arguments, schema)

--- a/spec/raix/mcp_spec.rb
+++ b/spec/raix/mcp_spec.rb
@@ -1,4 +1,8 @@
-describe "type coercion" do
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "MCP type coercion" do
   let(:test_class) do
     Class.new do
       include Raix::ChatCompletion
@@ -65,5 +69,260 @@ describe "type coercion" do
 
     expect(result["x"]).to eq(100)
     expect(result["y"]).to eq(50.5)
+  end
+
+  it "coerces arrays of objects with item schemas" do
+    instance = test_class.new
+
+    schema = {
+      "properties" => {
+        "users" => {
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "id" => { "type" => "integer" },
+              "age" => { "type" => "number" },
+              "active" => { "type" => "boolean" }
+            }
+          }
+        }
+      }
+    }
+
+    arguments = {
+      "users" => [
+        { "id" => "123", "age" => "25.5", "active" => "true" },
+        { "id" => "456", "age" => "30", "active" => "false" }
+      ]
+    }
+
+    result = instance.send(:coerce_arguments, arguments, schema)
+
+    expect(result["users"]).to be_a(Array)
+    expect(result["users"].length).to eq(2)
+
+    first_user = result["users"][0]
+    expect(first_user["id"]).to eq(123)
+    expect(first_user["id"]).to be_a(Integer)
+    expect(first_user["age"]).to eq(25.5)
+    expect(first_user["age"]).to be_a(Float)
+    expect(first_user["active"]).to eq(true)
+    expect(first_user["active"]).to be_a(TrueClass)
+
+    second_user = result["users"][1]
+    expect(second_user["id"]).to eq(456)
+    expect(second_user["active"]).to eq(false)
+  end
+
+  it "handles nested object coercion" do
+    instance = test_class.new
+
+    schema = {
+      "properties" => {
+        "config" => {
+          "type" => "object",
+          "properties" => {
+            "settings" => {
+              "type" => "object",
+              "properties" => {
+                "max_retries" => { "type" => "integer" },
+                "timeout" => { "type" => "number" },
+                "debug" => { "type" => "boolean" }
+              }
+            },
+            "metadata" => {
+              "type" => "object",
+              "properties" => {
+                "version" => { "type" => "number" }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    arguments = {
+      "config" => {
+        "settings" => {
+          "max_retries" => "3",
+          "timeout" => "30.5",
+          "debug" => "true"
+        },
+        "metadata" => {
+          "version" => "1.2"
+        }
+      }
+    }
+
+    result = instance.send(:coerce_arguments, arguments, schema)
+
+    expect(result["config"]["settings"]["max_retries"]).to eq(3)
+    expect(result["config"]["settings"]["max_retries"]).to be_a(Integer)
+    expect(result["config"]["settings"]["timeout"]).to eq(30.5)
+    expect(result["config"]["settings"]["timeout"]).to be_a(Float)
+    expect(result["config"]["settings"]["debug"]).to eq(true)
+    expect(result["config"]["metadata"]["version"]).to eq(1.2)
+  end
+
+  it "handles JSON string inputs for arrays and objects" do
+    instance = test_class.new
+
+    schema = {
+      "properties" => {
+        "tags" => { "type" => "array" },
+        "config" => {
+          "type" => "object",
+          "properties" => {
+            "enabled" => { "type" => "boolean" }
+          }
+        }
+      }
+    }
+
+    arguments = {
+      "tags" => '["tag1", "tag2", "tag3"]',
+      "config" => '{"enabled": "true", "extra": "value"}'
+    }
+
+    result = instance.send(:coerce_arguments, arguments, schema)
+
+    expect(result["tags"]).to eq(["tag1", "tag2", "tag3"])
+    expect(result["config"]["enabled"]).to eq(true)
+    expect(result["config"]["extra"]).to eq("value") # preserves extra properties
+  end
+
+  it "handles invalid JSON gracefully" do
+    instance = test_class.new
+
+    schema = {
+      "properties" => {
+        "data" => { "type" => "array" }
+      }
+    }
+
+    arguments = {
+      "data" => "not valid json ["
+    }
+
+    result = instance.send(:coerce_arguments, arguments, schema)
+
+    # Should return the original value when JSON parsing fails
+    expect(result["data"]).to eq("not valid json [")
+  end
+
+  it "handles type mismatches gracefully" do
+    instance = test_class.new
+
+    schema = {
+      "properties" => {
+        "count" => { "type" => "integer" },
+        "ratio" => { "type" => "number" },
+        "flag" => { "type" => "boolean" }
+      }
+    }
+
+    arguments = {
+      "count" => "not a number",
+      "ratio" => "also not a number",
+      "flag" => "maybe"
+    }
+
+    result = instance.send(:coerce_arguments, arguments, schema)
+
+    # Should return original values when coercion is not possible
+    expect(result["count"]).to eq("not a number")
+    expect(result["ratio"]).to eq("also not a number")
+    expect(result["flag"]).to eq("maybe")
+  end
+
+  it "preserves additional properties not in schema" do
+    instance = test_class.new
+
+    schema = {
+      "properties" => {
+        "known" => { "type" => "integer" }
+      }
+    }
+
+    arguments = {
+      "known" => "42",
+      "unknown" => "value",
+      "extra" => { "nested" => true }
+    }
+
+    result = instance.send(:coerce_arguments, arguments, schema)
+
+    expect(result["known"]).to eq(42)
+    expect(result["unknown"]).to eq("value")
+    expect(result["extra"]).to eq({ "nested" => true })
+  end
+
+  it "handles symbol and string keys interchangeably" do
+    instance = test_class.new
+
+    schema = {
+      "properties" => {
+        "value" => { "type" => "integer" }
+      }
+    }
+
+    arguments = {
+      value: "100"  # symbol key
+    }
+
+    result = instance.send(:coerce_arguments, arguments, schema)
+
+    expect(result["value"]).to eq(100)
+    expect(result[:value]).to eq(100) # with_indifferent_access allows both
+  end
+
+  it "handles nil values appropriately" do
+    instance = test_class.new
+
+    schema = {
+      "properties" => {
+        "optional_int" => { "type" => "integer" },
+        "optional_bool" => { "type" => "boolean" }
+      }
+    }
+
+    arguments = {
+      "optional_int" => nil,
+      "other_field" => "value"
+    }
+
+    result = instance.send(:coerce_arguments, arguments, schema)
+
+    # nil values are preserved as-is (not coerced)
+    expect(result["optional_int"]).to be_nil
+    expect(result["other_field"]).to eq("value")
+  end
+
+  it "coerces boolean edge cases correctly" do
+    instance = test_class.new
+
+    schema = {
+      "properties" => {
+        "bool1" => { "type" => "boolean" },
+        "bool2" => { "type" => "boolean" },
+        "bool3" => { "type" => "boolean" },
+        "bool4" => { "type" => "boolean" }
+      }
+    }
+
+    arguments = {
+      "bool1" => true,
+      "bool2" => false,
+      "bool3" => "true",
+      "bool4" => "false"
+    }
+
+    result = instance.send(:coerce_arguments, arguments, schema)
+
+    expect(result["bool1"]).to eq(true)
+    expect(result["bool2"]).to eq(false)
+    expect(result["bool3"]).to eq(true)
+    expect(result["bool4"]).to eq(false)
   end
 end


### PR DESCRIPTION
## Summary

This PR adds important enhancements to the MCP (Model Context Protocol) integration:

- **Image content support** - MCP servers can now return image data which is properly handled and returned as structured JSON
- **Automatic type coercion** - String parameters are automatically converted to their proper types based on the tool's JSON schema
- **Complex type handling** - Support for arrays of objects with nested coercion

## Changes from @macournoyer

These commits were cherry-picked from @macournoyer's fork:
- `f8d6416` Add support for image types
- `de64d2f` Added params type coercion  
- `9c96def` Added params type coercion for arrays of objects

## Additional Changes

- Added comprehensive test coverage for all type coercion scenarios
- Fixed rubocop style issues

## Test Coverage

The PR includes extensive tests for:
- ✅ Arrays of objects with nested coercion
- ✅ Deeply nested object structures
- ✅ JSON string parsing for arrays and objects
- ✅ Error handling for invalid JSON
- ✅ Type mismatch handling
- ✅ Preservation of additional properties
- ✅ Symbol/string key handling
- ✅ Nil value handling
- ✅ Boolean edge cases
- ✅ Image content handling

All tests pass (53 examples, 0 failures).

## Example Usage

The type coercion allows MCP tools to receive properly typed arguments even when the LLM sends strings:

```ruby
# Schema defines x as integer, y as number
arguments = { "x" => "100", "y" => "50.5" }
# After coercion: { "x" => 100, "y" => 50.5 }

# Arrays of objects are properly coerced
arguments = {
  "users" => [
    { "id" => "123", "active" => "true" },
    { "id" => "456", "active" => "false" }
  ]
}
# After coercion: users[0]["id"] is 123 (Integer), users[0]["active"] is true (Boolean)
```

cc @macournoyer for review