### PR TITLE
Add ostruct dependency to prevent warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activesupport (>= 6.0)
       faraday-retry (~> 2.0)
       open_router (~> 0.2)
+      ostruct
       ruby-openai (~> 7)
 
 GEM
@@ -97,6 +98,7 @@ GEM
       dotenv (>= 2)
       faraday (>= 1)
       faraday-multipart (>= 1)
+    ostruct (0.6.1)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)

--- a/raix.gemspec
+++ b/raix.gemspec
@@ -31,5 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 6.0"
   spec.add_dependency "faraday-retry", "~> 2.0"
   spec.add_dependency "open_router", "~> 0.2"
+  spec.add_dependency "ostruct"
   spec.add_dependency "ruby-openai", "~> 7"
 end


### PR DESCRIPTION
In Ruby 3.4.4, this warning is emitted:

```
/Users/andy/.local/share/mise/installs/ruby/3.4.4/lib/ruby/3.4.0/ostruct.rb
was loaded from the standard library, but will no longer be part of the
default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of raix-0.9.1 to request adding ostruct
into its gemspec.
```