### PR TITLE
Update default OpenRouter model

### DIFF
--- a/lib/raix/configuration.rb
+++ b/lib/raix/configuration.rb
@@ -38,7 +38,7 @@ module Raix
 
     DEFAULT_MAX_TOKENS = 1000
     DEFAULT_MAX_COMPLETION_TOKENS = 16_384
-    DEFAULT_MODEL = "meta-llama/llama-3-8b-instruct:free"
+    DEFAULT_MODEL = "meta-llama/llama-3.3-8b-instruct:free"
     DEFAULT_TEMPERATURE = 0.0
 
     # Initializes a new instance of the Configuration class with default values.

--- a/spec/raix/chat_completion_spec.rb
+++ b/spec/raix/chat_completion_spec.rb
@@ -4,7 +4,7 @@ class MeaningOfLife
   include Raix::ChatCompletion
 
   def initialize
-    self.model = "meta-llama/llama-3-8b-instruct:free"
+    self.model = "meta-llama/llama-3.3-8b-instruct:free"
     self.seed = 9999 # try to get reproduceable results
     transcript << { user: "What is the meaning of life?" }
   end

--- a/spec/vcr/MeaningOfLife/does_a_completion_with_OpenRouter.yml
+++ b/spec/vcr/MeaningOfLife/does_a_completion_with_OpenRouter.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://openrouter.ai/api/v1/chat/completions
     body:
       encoding: UTF-8
-      string: '{"messages":[{"role":"user","content":"What is the meaning of life?"}],"model":"meta-llama/llama-3-8b-instruct:free","max_tokens":1000,"seed":9999,"temperature":0.0}'
+      string: '{"messages":[{"role":"user","content":"What is the meaning of life?"}],"model":"meta-llama/llama-3.3-8b-instruct:free","max_tokens":1000,"seed":9999,"temperature":0.0}'
     headers:
       Authorization:
       - Bearer REDACTED
@@ -27,7 +27,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 11 Nov 2024 01:39:50 GMT
+      - Sat, 31 May 2025 16:13:31 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -36,8 +36,6 @@ http_interactions:
       - keep-alive
       Access-Control-Allow-Origin:
       - "*"
-      Cf-Placement:
-      - local-EWR
       X-Clerk-Auth-Message:
       - Invalid JWT form. A JWT consists of three parts separated by dots. (reason=token-invalid,
         token-carrier=header)
@@ -50,81 +48,37 @@ http_interactions:
       Server:
       - cloudflare
       Cf-Ray:
-      - 8e0a921d8bb842a6-EWR
+      - 9487c24dcb3636b3-YYZ
     body:
       encoding: ASCII-8BIT
-      string: "\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n\n         \n\n         \n\n         \n\n
-        \        \n\n         \n\n         \n{\"id\":\"gen-1731289190-DSagLOMzjok7vvakKnSH\",\"provider\":\"Lepton\",\"model\":\"meta-llama/llama-3-8b-instruct\",\"object\":\"chat.completion\",\"created\":1731289190,\"choices\":[{\"logprobs\":null,\"finish_reason\":\"stop\",\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"The
-        meaning of life is a question that has puzzled philosophers, scientists, and
-        thinkers for centuries. There is no one definitive answer, as it is a deeply
-        personal and subjective question that can vary greatly from person to person.
-        However, here are some possible perspectives and insights that may help shed
-        some light on this question:\\n\\n1. **Existentialism**: According to existentialist
-        philosophers like Jean-Paul Sartre and Martin Heidegger, the meaning of life
-        is not predetermined or given by external forces. Instead, it is created by
-        individuals through their choices, actions, and experiences. In this view,
-        the meaning of life is subjective and personal, and it is up to each individual
-        to create their own meaning.\\n2. **Purpose**: Some people believe that the
-        meaning of life is to find one's purpose or passion. This could be a career,
-        a hobby, or a personal goal that brings fulfillment and satisfaction. According
-        to this view, the meaning of life is to pursue one's purpose with dedication
-        and enthusiasm.\\n3. **Happiness**: Another perspective is that the meaning
-        of life is to find happiness and well-being. This could be achieved through
-        relationships, personal growth, or a sense of accomplishment. According to
-        this view, the meaning of life is to cultivate happiness and fulfillment in
-        one's life.\\n4. **Spirituality**: For many people, the meaning of life is
-        connected to their spiritual beliefs or practices. This could include a sense
-        of connection to a higher power, a sense of purpose or direction, or a sense
-        of transcendence or unity with the universe.\\n5. **Evolutionary perspective**:
-        From an evolutionary perspective, the meaning of life could be seen as the
-        perpetuation of the species. According to this view, the meaning of life is
-        to survive and reproduce, ensuring the continuation of the human species.\\n6.
-        **Cosmic perspective**: Some people believe that the meaning of life is to
-        understand our place in the universe and to find our connection to the cosmos.
-        According to this view, the meaning of life is to explore, discover, and appreciate
-        the vastness and complexity of the universe.\\n7. **Moral purpose**: Another
-        perspective is that the meaning of life is to live a life of moral purpose
-        and integrity. According to this view, the meaning of life is to act with
-        kindness, compassion, and justice, and to make a positive impact on the world.\\n8.
-        **Self-actualization**: According to humanistic psychologist Abraham Maslow,
-        the meaning of life is to self-actualize, or to become the best version of
-        oneself. According to this view, the meaning of life is to realize one's full
-        potential and to live a life of authenticity and purpose.\\n\\nUltimately,
-        the meaning of life is a deeply personal and subjective question that can
-        vary greatly from person to person. While these perspectives may provide some
-        insights, the meaning of life is ultimately a mystery that each individual
-        must discover for themselves.\",\"refusal\":\"\"}}],\"usage\":{\"prompt_tokens\":17,\"completion_tokens\":591,\"total_tokens\":608}}"
-  recorded_at: Mon, 11 Nov 2024 01:39:56 GMT
+      string: "\n         \n\n         \n\n         \n\n         \n\n         \n{\"id\":\"gen-1748708011-Q5TMAKDhTBwiwgBqYyxU\",\"provider\":\"Meta\",\"model\":\"meta-llama/llama-3.3-8b-instruct:free\",\"object\":\"chat.completion\",\"created\":1748708011,\"choices\":[{\"logprobs\":null,\"finish_reason\":\"stop\",\"native_finish_reason\":\"stop\",\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"A
+        question that has puzzled philosophers, theologians, scientists, and everyday
+        people for centuries! The meaning of life is a complex and multifaceted concept
+        that can be interpreted in many ways. Here are some possible perspectives:\\n\\n1.
+        **Biological perspective**: From a biological standpoint, the meaning of life
+        is to survive and reproduce, ensuring the continuation of one's genetic lineage.\\n2.
+        **Philosophical perspective**: Philosophers have offered various answers,
+        such as:\\n\\t* **Hedonism**: The pursuit of pleasure and happiness.\\n\\t*
+        **Eudaimonia**: Living a virtuous and fulfilling life, as described by Aristotle.\\n\\t*
+        **Existentialism**: Creating one's own meaning in life, as there is no inherent
+        or objective meaning.\\n3. **Religious perspective**: Many religions offer
+        answers, such as:\\n\\t* **Spiritual growth**: Seeking a deeper connection
+        with a higher power or the divine.\\n\\t* **Moral purpose**: Living a life
+        of service, compassion, and righteousness.\\n\\t* **Salvation**: Achieving
+        spiritual salvation or enlightenment.\\n4. **Psychological perspective**:
+        From a psychological standpoint, the meaning of life can be related to:\\n\\t*
+        **Personal growth**: Developing one's skills, abilities, and character.\\n\\t*
+        **Relationships**: Building and maintaining meaningful connections with others.\\n\\t*
+        **Contributing to society**: Making a positive impact on the world.\\n5. **Humanistic
+        perspective**: This perspective emphasizes the importance of:\\n\\t* **Autonomy**:
+        Living an independent and self-directed life.\\n\\t* **Creativity**: Expressing
+        oneself through art, music, writing, or other forms of creative expression.\\n\\t*
+        **Self-actualization**: Realizing one's full potential and living a life of
+        purpose.\\n6. **Scientific perspective**: Some scientists argue that the meaning
+        of life is:\\n\\t* **Evolutionary**: Contributing to the survival and advancement
+        of the human species.\\n\\t* **Cosmological**: Understanding our place in
+        the universe and the laws that govern it.\\n\\nUltimately, the meaning of
+        life is a highly personal and subjective concept that can vary greatly from
+        person to person. What gives your life meaning?\",\"refusal\":null,\"reasoning\":null}}],\"usage\":{\"prompt_tokens\":17,\"completion_tokens\":442,\"total_tokens\":459}}"
+  recorded_at: Sat, 31 May 2025 16:13:33 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
:wave: I'm trying raix for the first time and encountered this failure for chat completions:

```
the server responded with status 404 (Faraday::ResourceNotFound)
````

Here's the underlying error:

```
{"error":{"message":"No endpoints found for meta-llama/llama-3-8b-instruct:free.","code":404},"user_id":"..."}
```

I've updated the code and tests to use the currently available version of that model.

(I imagine this will break again in future when the available OpenRouter models are updated. Perhaps it would be better to programmatically pick a model using their API).