### PR TITLE
Bump ruby-openai to ~8.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       faraday-retry (~> 2.0)
       open_router (~> 0.2)
       ostruct
-      ruby-openai (~> 7)
+      ruby-openai (~> 8.1)
 
 GEM
   remote: https://rubygems.org/
@@ -148,7 +148,7 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.31.2)
       parser (>= 3.3.0.4)
-    ruby-openai (7.1.0)
+    ruby-openai (8.1.0)
       event_stream_parser (>= 0.3.0, < 2.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)

--- a/raix.gemspec
+++ b/raix.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday-retry", "~> 2.0"
   spec.add_dependency "open_router", "~> 0.2"
   spec.add_dependency "ostruct"
-  spec.add_dependency "ruby-openai", "~> 7"
+  spec.add_dependency "ruby-openai", "~> 8.1"
 end


### PR DESCRIPTION
This PR bumps ruby-openai gem to `~8.1` to solve compatibility issues with other gems.