### PR TITLE
fix error with openai-client and response format

### DIFF
--- a/lib/raix/response_format.rb
+++ b/lib/raix/response_format.rb
@@ -44,6 +44,8 @@ module Raix
       }
     end
 
+    alias :as_json :to_schema
+
     private
 
     def decode(input)


### PR DESCRIPTION
When using openai-client and passing a Riax::ResponseFormat as indicated in the README, openai will respond with a 400 error:
```
{"error"=>{"message"=>"Missing required parameter: 'response_format.type'.", "type"=>"invalid_request_error", "param"=>"response_format.type", "code"=>"missing_required_parameter"}}
```
This is because the library seems to be using as_json instead of to_json to convert the object. So adding this alias fixes the issue.