### PR TITLE
fix: forward full JSON schema for function tool params to RubyLLM (2.0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## [Unreleased]
 
+## [2.0.5] - 2026-06-04
+
 ### Fixed
 - `Raix::Configuration` no longer defaults `temperature` to `0.0`. The default was being injected into every request payload, which OpenRouter rejects with `404 No endpoints found that can handle the requested parameters` when routed to providers whose `supported_parameters` list omits `temperature` (notably Anthropic's Claude 4.7 family) and `provider.require_parameters: true` is set — which Raix sets automatically whenever `json: true` is passed to `chat_completion`. Callers that want a specific temperature should set one explicitly (`self.temperature = 0.0` on the including class, or `Raix.configure { |c| c.temperature = 0.0 }` globally); when unset, Raix now omits the parameter and the provider's own server-side default applies. `max_tokens`, `max_completion_tokens`, and `model` defaults are unchanged.
+- `Raix::FunctionToolAdapter` now forwards the full JSON-Schema dict for each function parameter to RubyLLM instead of rebuilding it from `type` + `description` only. Rich schema fields like `additionalProperties`, `items`, `enum`, and nested `properties` were silently dropped, leaving providers (notably Gemini's structured output via OpenRouter) to invent degenerate shapes for `type: object` arguments — e.g. emitting `{"prefix" => false}` instead of `{"prefix:title" => "..."}`. Function declarations with rich object schemas now reach the provider intact.
+- The outer tool-args schema continues to inject `additionalProperties: false` and `strict: true` by default for OpenAI strict-mode compatibility, but consumers can override either by setting them explicitly in the function declaration.
 
 ## [2.0.4] - 2026-05-19
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    raix (2.0.4)
+    raix (2.0.5)
       activesupport (>= 6.0)
       faraday-retry (~> 2.0)
       ostruct

--- a/lib/raix/function_tool_adapter.rb
+++ b/lib/raix/function_tool_adapter.rb
@@ -7,10 +7,18 @@ module Raix
       tool_class = Class.new(RubyLLM::Tool) do
         description function_def[:description] if function_def[:description]
 
-        # Define parameters based on function definition
-        function_def[:parameters][:properties]&.each do |param_name, param_def|
-          required = function_def[:parameters][:required]&.include?(param_name)
-          param param_name.to_sym, type: param_def[:type], desc: param_def[:description], required:
+        # Forward the full JSON-schema parameter dict to RubyLLM rather than
+        # rebuilding it field-by-field via `param(...)`. The per-field path
+        # only carried `type` and `description`, which silently dropped richer
+        # schema like `additionalProperties`, `items`, `enum`, or nested
+        # `properties` — leaving providers (notably Gemini's structured output)
+        # to invent degenerate shapes for `type: object` arguments.
+        if function_def[:parameters].is_a?(Hash) && function_def[:parameters][:properties].present?
+          # RubyLLM's `params(schema)` path forwards the schema verbatim and, unlike the
+          # per-field `param(...)` path, does not inject the OpenAI strict-mode guards. Default
+          # them on so existing tools keep strict behavior, while letting a function declaration
+          # override either by setting it explicitly.
+          params({ additionalProperties: false, strict: true }.merge(function_def[:parameters]))
         end
 
         # Store reference to the instance and function name

--- a/lib/raix/version.rb
+++ b/lib/raix/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Raix
-  VERSION = "2.0.4"
+  VERSION = "2.0.5"
 end

--- a/spec/raix/function_tool_adapter_spec.rb
+++ b/spec/raix/function_tool_adapter_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Raix::FunctionToolAdapter do
+  let(:instance_class) do
+    Class.new do
+      include Raix::ChatCompletion
+      include Raix::FunctionDispatch
+
+      function :upsert_entity,
+               "Create or update an entity.",
+               type: { type: "string", description: "Class URI." },
+               uri: { type: "string", description: "Entity URI." },
+               properties: {
+                 type: "object",
+                 description: "Literal predicates keyed by prefixed name.",
+                 additionalProperties: { type: "string" }
+               },
+               links: {
+                 type: "object",
+                 description: "URI predicates keyed by prefixed name.",
+                 additionalProperties: { type: "string" }
+               } do |args|
+        args
+      end
+
+      function :ping, "no-args function" do |_args|
+        :pong
+      end
+    end
+  end
+
+  describe ".create_tool_from_function" do
+    it "forwards rich JSON-schema fields (additionalProperties, etc.) on object parameters" do
+      tool = described_class.create_tool_from_function(instance_class.functions[0], instance_class.new)
+      schema = tool.params_schema
+
+      properties_param = schema["properties"]["properties"]
+      expect(properties_param["type"]).to eq("object")
+      expect(properties_param["additionalProperties"]).to eq("type" => "string")
+
+      links_param = schema["properties"]["links"]
+      expect(links_param["additionalProperties"]).to eq("type" => "string")
+    end
+
+    it "preserves strict OpenAI-style guards at the outer schema by default" do
+      tool = described_class.create_tool_from_function(instance_class.functions[0], instance_class.new)
+      schema = tool.params_schema
+
+      expect(schema["additionalProperties"]).to eq(false)
+      expect(schema["strict"]).to eq(true)
+    end
+
+    it "skips schema generation for functions that declare no parameters" do
+      tool = described_class.create_tool_from_function(instance_class.functions[1], instance_class.new)
+      expect(tool.params_schema).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## What

`Raix::FunctionToolAdapter` rebuilt each function parameter field-by-field via RubyLLM's `param(...)`, which only carried `type` and `description`. Rich JSON-Schema fields — `additionalProperties`, `items`, `enum`, and nested `properties` — were silently dropped.

The visible symptom: providers (notably **Gemini structured output via OpenRouter**) had no real schema for `type: object` arguments, so they invented degenerate shapes — e.g. emitting `{"prefix" => false}` instead of `{"prefix:title" => "..."}`.

## Fix

Forward the full schema dict via RubyLLM's `params(schema)` path instead of rebuilding it.

That path forwards the schema verbatim and, unlike `param(...)`, does **not** inject the OpenAI strict-mode guards. So the adapter now defaults `additionalProperties: false` and `strict: true` at the outer schema (preserving prior behavior), while letting a function declaration override either by setting it explicitly.

```ruby
params({ additionalProperties: false, strict: true }.merge(function_def[:parameters]))
```

## Tests

New `spec/raix/function_tool_adapter_spec.rb` covers:
- Rich JSON-Schema fields (`additionalProperties` on nested object params) survive to `params_schema`
- Outer strict-mode guards (`additionalProperties: false`, `strict: true`) preserved by default
- No-parameter functions still produce no schema

Full suite: **107 examples, 0 failures, 1 pending**. RuboCop clean.

## Versioning

`2.0.4` was already released upstream for an unrelated change, so this cuts **2.0.5** and rolls the pending temperature-default fix out of `[Unreleased]` into `[2.0.5]` alongside this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)