### PR TITLE
fix: apply cache_control for Claude 4.x models (not just claude-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Fixed
+- `Raix::MessageAdapters::Base` now applies Anthropic prompt caching for all Claude models, not just the `claude-3` family. The guard that converts large content into the multipart `cache_control` format only matched model ids containing `anthropic/claude-3`, so configuring `cache_at` on a Claude 4.x model (e.g. `anthropic/claude-sonnet-4`, `anthropic/claude-opus-4-7`) silently did nothing — content was sent uncached and the prompt-cache discount was never realized. The check now matches `anthropic/claude`, covering the current Claude 4.x ids alongside `claude-3`. Behavior for non-Claude models is unchanged.
+
 ## [2.0.5] - 2026-06-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 
 ### Fixed
-- `Raix::MessageAdapters::Base` now applies Anthropic prompt caching for all Claude models, not just the `claude-3` family. The guard that converts large content into the multipart `cache_control` format only matched model ids containing `anthropic/claude-3`, so configuring `cache_at` on a Claude 4.x model (e.g. `anthropic/claude-sonnet-4`, `anthropic/claude-opus-4-7`) silently did nothing — content was sent uncached and the prompt-cache discount was never realized. The check now matches `anthropic/claude`, covering the current Claude 4.x ids alongside `claude-3`. Behavior for non-Claude models is unchanged.
+- `Raix::MessageAdapters::Base` now applies Anthropic prompt caching for all Claude models, not just the `claude-3` family. The guard that converts large content into the multipart `cache_control` format only matched model ids containing `anthropic/claude-3`, so configuring `cache_at` on a Claude 4.x model (e.g. `anthropic/claude-sonnet-4`, `anthropic/claude-opus-4-7`) silently did nothing — content was sent uncached and the prompt-cache discount was never realized. The check now matches `anthropic/claude`, covering the current Claude 4.x ids alongside `claude-3`. The wrapping is also limited to plain string content so multimodal `image_url` arrays pass through to `MultimodalContentAdapter` unchanged. Behavior for non-Claude models is unchanged.
 
 ## [2.0.5] - 2026-06-04
 

--- a/lib/raix/message_adapters/base.rb
+++ b/lib/raix/message_adapters/base.rb
@@ -39,8 +39,10 @@ module Raix
         else
           raise ArgumentError, "Invalid message format: #{message.inspect}"
         end.tap do |msg|
-          # convert to anthropic multipart format if model is an anthropic claude and cache_at is set
-          if model.to_s.include?("anthropic/claude") && cache_at && msg[:content].to_s.length > cache_at.to_i
+          # convert to anthropic multipart format if model is an anthropic claude and cache_at is set.
+          # only wrap plain string content; array content (e.g. multimodal image_url parts) is left
+          # untouched so MultimodalContentAdapter can still translate it downstream.
+          if model.to_s.include?("anthropic/claude") && cache_at && msg[:content].is_a?(String) && msg[:content].length > cache_at.to_i
             msg[:content] = [{ type: "text", text: msg[:content], cache_control: { type: "ephemeral" } }]
           end
         end

--- a/lib/raix/message_adapters/base.rb
+++ b/lib/raix/message_adapters/base.rb
@@ -39,8 +39,8 @@ module Raix
         else
           raise ArgumentError, "Invalid message format: #{message.inspect}"
         end.tap do |msg|
-          # convert to anthropic multipart format if model is claude-3 and cache_at is set
-          if model.to_s.include?("anthropic/claude-3") && cache_at && msg[:content].to_s.length > cache_at.to_i
+          # convert to anthropic multipart format if model is an anthropic claude and cache_at is set
+          if model.to_s.include?("anthropic/claude") && cache_at && msg[:content].to_s.length > cache_at.to_i
             msg[:content] = [{ type: "text", text: msg[:content], cache_control: { type: "ephemeral" } }]
           end
         end

--- a/spec/raix/message_adapters/base_spec.rb
+++ b/spec/raix/message_adapters/base_spec.rb
@@ -35,5 +35,15 @@ RSpec.describe Raix::MessageAdapters::Base do
       expected = { role: "user", content: [{ type: "text", text: "Hello" * 5, cache_control: { type: "ephemeral" } }] }
       expect(adapter.transform(message)).to eq(expected)
     end
+
+    context "with a Claude 4 model" do
+      let(:context) { double("Context", model: "anthropic/claude-sonnet-4", cache_at: 10) }
+
+      it "wraps large content with cache_control" do
+        message = { user: "Hello" * 5 }
+        expected = { role: "user", content: [{ type: "text", text: "Hello" * 5, cache_control: { type: "ephemeral" } }] }
+        expect(adapter.transform(message)).to eq(expected)
+      end
+    end
   end
 end

--- a/spec/raix/message_adapters/base_spec.rb
+++ b/spec/raix/message_adapters/base_spec.rb
@@ -44,6 +44,15 @@ RSpec.describe Raix::MessageAdapters::Base do
         expected = { role: "user", content: [{ type: "text", text: "Hello" * 5, cache_control: { type: "ephemeral" } }] }
         expect(adapter.transform(message)).to eq(expected)
       end
+
+      it "leaves multimodal array content untouched" do
+        parts = [
+          { type: "text", text: "Hello" * 5 },
+          { type: "image_url", image_url: { url: "https://example.com/cat.png" } }
+        ]
+        message = { user: parts }
+        expect(adapter.transform(message)).to eq({ role: "user", content: parts })
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

`Raix::MessageAdapters::Base#content` only emits the Anthropic `cache_control` multipart shape when the model id contains the literal `anthropic/claude-3`:

```ruby
if model.to_s.include?("anthropic/claude-3") && cache_at && msg[:content].to_s.length > cache_at.to_i
```

The current Claude 4.x ids (`anthropic/claude-sonnet-4`, `anthropic/claude-opus-4-7`, `anthropic/claude-haiku-4-5`, …) don't contain the substring `claude-3`, so the guard never matches them. Setting `cache_at` on a Claude 4.x model silently does nothing: the content is sent as a plain string, no `cache_control` block is attached, and the prompt-cache discount is never applied. The gem already targets Claude 4.x elsewhere (e.g. `lib/raix/configuration.rb` references the Claude 4.7 family), so the caching path is the only place still pinned to `claude-3`.

## Fix

Broaden the guard in `lib/raix/message_adapters/base.rb` to match any Anthropic Claude model:

```ruby
if model.to_s.include?("anthropic/claude") && cache_at && msg[:content].to_s.length > cache_at.to_i
```

`anthropic/claude` is a prefix of every Anthropic Claude id, so this covers `claude-3` and the `*-4` family alike. Non-Claude models still fall through untouched — behavior is unchanged for anything that isn't an Anthropic Claude.

## Tests

Added an example in `spec/raix/message_adapters/base_spec.rb` that stubs a Claude 4 id (`anthropic/claude-sonnet-4`) and asserts large content is wrapped with `cache_control`. It fails against the old `claude-3`-only guard (content stays a bare string) and passes with the fix. The existing `claude-3` example is retained.

CHANGELOG entry added under `## [Unreleased]`.
