### PR TITLE
fix: enforce max_tool_calls (and repair stop_tool_calls_and_respond!) under the RubyLLM backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### Fixed
+- `max_tool_calls` is now enforced under the RubyLLM backend. RubyLLM drives the tool-call loop internally (`complete` → `handle_tool_calls` → `complete`) and only returns once the model stops calling tools, so the counting loop in `Raix::ChatCompletion` never saw a tool round — `max_tool_calls` was dead code and agentic loops ran unbounded. The budget is now enforced inside the generated `FunctionToolAdapter` tool wrapper, which increments a per-completion counter on each invocation and returns a `RubyLLM::Tool::Halt` (refusing to run the underlying function) once the count exceeds the budget. Enforcement is per call because a single model response can pack several parallel tool calls, all of which RubyLLM executes in one round even after one halts. On a halt, `chat_completion` issues one final completion with no tools (and drops `tool_choice`) and returns its text, appending the existing `"Maximum tool calls (N) exceeded…"` system message.
+- `stop_tool_calls_and_respond!` works again. It set a flag that only the (now unreachable) counting loop read, so under RubyLLM it did nothing. The tool wrapper now checks the flag after a successful tool execution and halts the loop, forcing a final text response.
+- `Raix::ChatCompletion` no longer crashes when RubyLLM's tool loop is halted. `chat.complete`/`#ask` return a `RubyLLM::Tool::Halt` (not a `Message`) in that case, and the response conversion called `#raw` / `#input_tokens` on it. `ruby_llm_request` now detects the `Halt` and hands it back for final-response handling.
+- Assistant tool-call messages replayed from the transcript into a fresh `RubyLLM::Chat` are now translated from Raix's OpenAI-style array-of-hashes shape into the `{ id => RubyLLM::ToolCall }` shape RubyLLM's providers expect. Previously this path (reachable via the forced final completion above) raised `NoMethodError: undefined method 'id' for nil` while rendering the request payload.
+
 ## [2.0.5] - 2026-06-04
 
 ### Fixed

--- a/lib/raix/chat_completion.rb
+++ b/lib/raix/chat_completion.rb
@@ -127,6 +127,11 @@ module Raix
       # Track tool call count
       tool_call_count = 0
 
+      # Reset the per-completion tool-call counter that FunctionToolAdapter's
+      # generated wrappers use to enforce max_tool_calls under the RubyLLM
+      # backend (see #increment_tool_call_count).
+      @tool_call_count = 0
+
       # set the model to the default if not provided
       self.model ||= configuration.model
 
@@ -145,6 +150,15 @@ module Raix
 
       begin
         response = ruby_llm_request(params:, model: openai || model, messages:, openai_override: openai)
+
+        # RubyLLM runs the entire tool-call loop inside chat.complete/#ask. When
+        # a generated tool halts that loop — because max_tool_calls was exceeded
+        # or stop_tool_calls_and_respond! was called — the return value is a
+        # RubyLLM::Tool::Halt rather than a Message. Re-issue one final
+        # completion with no tools; the shared handling below then returns its
+        # text/JSON as usual.
+        response = force_final_response_after_halt(response, params:, openai:) if response.is_a?(RubyLLM::Tool::Halt)
+
         retry_count = 0
         content = nil
 
@@ -298,7 +312,40 @@ module Raix
       public_send(function_name, arguments, cache)
     end
 
+    # Increments and returns the per-completion tool-call counter. Called by the
+    # generated FunctionToolAdapter wrappers to enforce max_tool_calls: RubyLLM
+    # runs the whole tool loop inside a single chat.complete, so Raix never sees
+    # the individual rounds and has to count from inside the tool. Internal API.
+    def increment_tool_call_count
+      @tool_call_count = @tool_call_count.to_i + 1
+    end
+
     private
+
+    # Issues the single final completion after RubyLLM's tool loop was halted.
+    # Rebuilds the conversation from the transcript — FunctionDispatch has
+    # already appended an assistant/tool message pair for every tool call that
+    # ran before the halt, so the transcript carries the full tool exchange —
+    # then completes once with no tools and returns the OpenAI-compatible hash.
+    def force_final_response_after_halt(halt, params:, openai:)
+      adapter = MessageAdapters::Base.new(self)
+      messages = transcript.flatten.compact.map { |msg| adapter.transform(msg) }
+
+      reason = halt.content
+      if reason.is_a?(FunctionToolAdapter::ToolCallsCapReached)
+        messages << { role: "system",
+                      content: "Maximum tool calls (#{reason.max_tool_calls}) exceeded. Please provide a final response to the user without calling any more tools." }
+      end
+
+      # Force a final response without tools. Drop tool_choice as well: a
+      # lingering tool_choice that forces tool use with no tools registered is a
+      # provider error.
+      final_params = params.dup
+      final_params[:tools] = nil
+      final_params.delete(:tool_choice)
+
+      ruby_llm_request(params: final_params, model: openai || model, messages:, openai_override: openai)
+    end
 
     def filtered_tools(tool_names)
       return nil if tool_names.blank?
@@ -357,8 +404,8 @@ module Raix
           has_user_message = true
           chat.add_message(role: :user, content: MultimodalContentAdapter.translate(content))
         when "assistant"
-          if msg[:tool_calls] || msg["tool_calls"]
-            chat.add_message(role: :assistant, content:, tool_calls: msg[:tool_calls] || msg["tool_calls"])
+          if (tool_calls = msg[:tool_calls] || msg["tool_calls"])
+            chat.add_message(role: :assistant, content:, tool_calls: normalize_tool_calls_for_ruby_llm(tool_calls))
           else
             chat.add_message(role: :assistant, content:)
           end
@@ -396,6 +443,13 @@ module Raix
       else
         # Non-streaming mode - return OpenAI-compatible response format
         response_message = has_user_message ? chat.complete : chat.ask
+
+        # A generated tool can halt RubyLLM's internal tool loop (max_tool_calls
+        # exceeded or stop_tool_calls_and_respond!). When that happens
+        # chat.complete/#ask returns a RubyLLM::Tool::Halt, not a Message, so it
+        # has no #raw / #input_tokens. Hand it straight back to chat_completion,
+        # which forces a final tool-less completion.
+        return response_message if response_message.is_a?(RubyLLM::Tool::Halt)
 
         # Pull through the raw provider payload when available. OpenRouter's
         # `id` is the only handle we have to look up authoritative billing
@@ -449,6 +503,25 @@ module Raix
 
       # Default to openrouter for model IDs with provider prefix
       :openrouter
+    end
+
+    # Raix's transcript stores assistant tool calls in OpenAI's array-of-hashes
+    # shape (`[{ id:, type:, function: { name:, arguments: } }]`), but RubyLLM's
+    # providers format tool calls from a Hash keyed by call id whose values
+    # respond to #id/#name/#arguments (RubyLLM::ToolCall). Translate so a
+    # transcript that already contains tool exchanges can be replayed back into
+    # a fresh RubyLLM chat — notably for the forced final completion after a
+    # max_tool_calls / stop_tool_calls_and_respond! halt.
+    def normalize_tool_calls_for_ruby_llm(tool_calls)
+      return tool_calls if tool_calls.is_a?(Hash) && tool_calls.values.all?(RubyLLM::ToolCall)
+
+      Array(tool_calls).each_with_object({}) do |raw, acc|
+        tc = raw.respond_to?(:with_indifferent_access) ? raw.with_indifferent_access : raw
+        function = tc[:function] || {}
+        arguments = function[:arguments]
+        arguments = JSON.parse(arguments) if arguments.is_a?(String) && arguments.present?
+        acc[tc[:id]] = RubyLLM::ToolCall.new(id: tc[:id], name: function[:name], arguments: arguments || {})
+      end
     end
   end
 end

--- a/lib/raix/chat_completion.rb
+++ b/lib/raix/chat_completion.rb
@@ -149,6 +149,15 @@ module Raix
       run_before_completion_hooks(params, messages)
 
       begin
+        # Snapshot the transcript length before the request. If a generated tool
+        # halts RubyLLM's loop, force_final_response_after_halt uses this to
+        # recover exactly the assistant/tool messages appended while executing
+        # tools and replay them after the original messages — which may not live
+        # in the transcript at all when `messages:` was passed explicitly. Only
+        # tools can trigger a halt, so skip the transcript read entirely when
+        # none are registered.
+        transcript_size_before = params[:tools].present? ? transcript.flatten.compact.size : 0
+
         response = ruby_llm_request(params:, model: openai || model, messages:, openai_override: openai)
 
         # RubyLLM runs the entire tool-call loop inside chat.complete/#ask. When
@@ -157,7 +166,9 @@ module Raix
         # RubyLLM::Tool::Halt rather than a Message. Re-issue one final
         # completion with no tools; the shared handling below then returns its
         # text/JSON as usual.
-        response = force_final_response_after_halt(response, params:, openai:) if response.is_a?(RubyLLM::Tool::Halt)
+        if response.is_a?(RubyLLM::Tool::Halt)
+          response = force_final_response_after_halt(response, params:, openai:, messages:, transcript_size_before:)
+        end
 
         retry_count = 0
         content = nil
@@ -322,14 +333,20 @@ module Raix
 
     private
 
-    # Issues the single final completion after RubyLLM's tool loop was halted.
-    # Rebuilds the conversation from the transcript — FunctionDispatch has
-    # already appended an assistant/tool message pair for every tool call that
-    # ran before the halt, so the transcript carries the full tool exchange —
+    # Issues the single final completion after RubyLLM's tool loop was halted,
     # then completes once with no tools and returns the OpenAI-compatible hash.
-    def force_final_response_after_halt(halt, params:, openai:)
+    #
+    # The final request is rebuilt from the original `messages` (the transcript
+    # or the caller-supplied `messages:` argument that drove the first request)
+    # plus the assistant/tool exchange FunctionDispatch appended while executing
+    # tools before the halt. `transcript_size_before` marks where that exchange
+    # begins, so the caller's system/user prompt is preserved even when it was
+    # never written into the transcript — otherwise the forced final call would
+    # answer from tool results (or stale transcript) alone.
+    def force_final_response_after_halt(halt, params:, openai:, messages:, transcript_size_before:)
       adapter = MessageAdapters::Base.new(self)
-      messages = transcript.flatten.compact.map { |msg| adapter.transform(msg) }
+      tool_exchange = transcript.flatten.compact.drop(transcript_size_before).map { |msg| adapter.transform(msg) }
+      messages += tool_exchange
 
       reason = halt.content
       if reason.is_a?(FunctionToolAdapter::ToolCallsCapReached)

--- a/lib/raix/function_tool_adapter.rb
+++ b/lib/raix/function_tool_adapter.rb
@@ -3,6 +3,12 @@
 module Raix
   # Adapter to convert Raix function declarations to RubyLLM::Tool instances
   class FunctionToolAdapter
+    # Sentinels wrapped in a RubyLLM::Tool::Halt so that ChatCompletion can tell
+    # *why* RubyLLM's internal tool loop was halted from inside a generated tool
+    # wrapper. Internal API — not intended for use outside Raix.
+    ToolCallsCapReached = Struct.new(:max_tool_calls)
+    StopToolCallsRequested = Struct.new(:result)
+
     def self.create_tool_from_function(function_def, instance)
       tool_class = Class.new(RubyLLM::Tool) do
         description function_def[:description] if function_def[:description]
@@ -25,9 +31,33 @@ module Raix
         define_method(:raix_instance) { instance }
         define_method(:raix_function_name) { function_def[:name] }
 
-        # Override execute to call the Raix function
+        # Override execute to call the Raix function.
+        #
+        # The max_tool_calls budget is enforced here, inside the generated
+        # wrapper, because RubyLLM drives the tool loop internally
+        # (complete -> handle_tool_calls -> complete) and never yields control
+        # back to Raix between rounds. Counting must therefore happen per tool
+        # invocation: a single model response can pack several parallel tool
+        # calls, all of which RubyLLM executes in one round even after one has
+        # halted, so each wrapper checks the shared counter independently.
         define_method(:execute) do |**args|
-          raix_instance.public_send(raix_function_name, args.with_indifferent_access, nil)
+          if raix_instance.increment_tool_call_count > raix_instance.max_tool_calls
+            # Refuse to run the underlying function and halt the loop. RubyLLM
+            # returns this Halt from chat.complete; ChatCompletion turns it into
+            # a final, tool-less completion.
+            halt(ToolCallsCapReached.new(raix_instance.max_tool_calls))
+          else
+            result = raix_instance.public_send(raix_function_name, args.with_indifferent_access, nil)
+
+            # stop_tool_calls_and_respond! sets a flag that only the old (now
+            # unreachable) counting loop used to read. Honor it here so it still
+            # forces a final text response under the RubyLLM backend.
+            if raix_instance.stop_tool_calls_and_respond
+              halt(StopToolCallsRequested.new(result))
+            else
+              result
+            end
+          end
         end
       end
 

--- a/spec/raix/max_tool_calls_spec.rb
+++ b/spec/raix/max_tool_calls_spec.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+# Regression coverage for max_tool_calls enforcement under the RubyLLM backend.
+#
+# RubyLLM drives the whole tool-call loop internally (complete ->
+# handle_tool_calls -> complete) and only returns once the model stops calling
+# tools. The counting loop in ChatCompletion therefore never saw a tool round,
+# so `max_tool_calls` and `stop_tool_calls_and_respond!` were both dead. The fix
+# enforces the budget inside the generated FunctionToolAdapter wrapper, which
+# returns a RubyLLM::Tool::Halt to stop the loop; ChatCompletion then forces one
+# final completion without tools.
+
+# A fake RubyLLM::Chat that records what Raix does to it and lets each spec
+# script what `complete` returns. The same instance is handed back for every
+# `RubyLLM.chat` call (transcript memo + each request), matching how the real
+# backend reuses one conversation. `complete`/`ask` invoke the provided behavior
+# with the chat and the 1-based completion number so a spec can run tools on the
+# first pass and return a final message on the forced second pass.
+class ScriptedRubyLLMChat
+  attr_reader :instructions, :tools, :with_tool_count, :complete_count, :tool_count_at_complete
+
+  def initialize(&behavior)
+    @behavior = behavior
+    @instructions = []
+    @tools = {}
+    @with_tool_count = 0
+    @complete_count = 0
+    @tool_count_at_complete = []
+  end
+
+  def with_instructions(content, **)
+    @instructions << content
+    self
+  end
+
+  def add_message(**) = self
+  def reset_messages!; end
+  def messages = []
+  def with_temperature(_) = self
+  def with_params(**) = self
+
+  def with_tool(tool)
+    @with_tool_count += 1
+    @tools[tool.name.to_sym] = tool
+    self
+  end
+
+  def ask(&) = complete(&)
+
+  def complete(&)
+    @complete_count += 1
+    @tool_count_at_complete << @with_tool_count
+    @behavior.call(self, @complete_count)
+  end
+end
+
+class ToolBudgetProbe
+  include Raix::ChatCompletion
+  include Raix::FunctionDispatch
+
+  attr_reader :work_executions, :finish_executions
+
+  function :do_work, "does a unit of work", n: { type: "integer" } do |_args|
+    @work_executions += 1
+    "work result #{@work_executions}"
+  end
+
+  function :finish_now, "wrap things up" do |_args|
+    @finish_executions += 1
+    stop_tool_calls_and_respond!
+    "stopping"
+  end
+
+  def initialize
+    @work_executions = 0
+    @finish_executions = 0
+    transcript << { user: "please work" }
+  end
+end
+
+RSpec.describe Raix::ChatCompletion, "max_tool_calls enforcement under RubyLLM" do
+  subject(:probe) { ToolBudgetProbe.new }
+
+  def final_message(content)
+    instance_double(
+      "RubyLLM::Message",
+      content:,
+      tool_calls: nil,
+      tool_call?: false,
+      input_tokens: 5,
+      output_tokens: 5,
+      model_id: "test-model",
+      raw: nil
+    )
+  end
+
+  # Simulate a round in which the model issues `count` calls to `tool_name`,
+  # exactly as RubyLLM's handle_tool_calls does: every call runs even after one
+  # halts, and the halt (if any) is what the loop returns.
+  def run_round(chat, tool_name, count)
+    halt = nil
+    count.times do |i|
+      result = chat.tools[tool_name].call({ n: i })
+      halt ||= result if result.is_a?(RubyLLM::Tool::Halt)
+    end
+    halt
+  end
+
+  let(:fake_chat) { ScriptedRubyLLMChat.new(&behavior) }
+
+  before { allow(RubyLLM).to receive(:chat).and_return(fake_chat) }
+
+  context "when the model keeps calling tools past the budget" do
+    # One call per round; the loop runs until the wrapper halts.
+    let(:behavior) do
+      lambda do |chat, n|
+        if n == 1
+          halt = nil
+          10.times do
+            result = chat.tools[:do_work].call({ n: 1 })
+            if result.is_a?(RubyLLM::Tool::Halt)
+              halt = result
+              break
+            end
+          end
+          halt || raise("expected the wrapper to halt but it never did")
+        else
+          final_message("final answer after cap")
+        end
+      end
+    end
+
+    it "refuses the tool call that exceeds max_tool_calls and returns a forced final response" do
+      response = probe.chat_completion(max_tool_calls: 2)
+
+      expect(response).to eq("final answer after cap")
+      # do_work ran exactly twice (calls 1 and 2); the 3rd was refused.
+      expect(probe.work_executions).to eq(2)
+    end
+
+    it "issues the final completion without tools and injects the limit system message" do
+      probe.chat_completion(max_tool_calls: 2)
+
+      expect(fake_chat.complete_count).to eq(2)
+      # 2 tools registered before the first completion, 0 more before the forced
+      # final one -> the final pass carries no tools.
+      expect(fake_chat.tool_count_at_complete).to eq([2, 2])
+      expect(fake_chat.instructions).to include(a_string_matching(/Maximum tool calls \(2\) exceeded/))
+    end
+  end
+
+  context "when a single response packs several parallel tool calls" do
+    # All calls happen in one round, mirroring parallel tool calls in one model
+    # response.
+    let(:behavior) do
+      lambda do |chat, n|
+        n == 1 ? run_round(chat, :do_work, 5) : final_message("final answer parallel")
+      end
+    end
+
+    it "enforces the cap per call so the round cannot blow past it" do
+      response = probe.chat_completion(max_tool_calls: 2)
+
+      expect(response).to eq("final answer parallel")
+      # Only the first 2 of the 5 parallel calls ran; the rest were refused.
+      expect(probe.work_executions).to eq(2)
+    end
+  end
+
+  context "when a tool calls stop_tool_calls_and_respond!" do
+    let(:behavior) do
+      lambda do |chat, n|
+        if n == 1
+          chat.tools[:finish_now].call({})
+        else
+          final_message("final answer after stop")
+        end
+      end
+    end
+
+    it "halts the loop and forces a final text response" do
+      response = probe.chat_completion(max_tool_calls: 25)
+
+      expect(response).to eq("final answer after stop")
+      # The function itself ran (unlike a cap refusal), then the loop stopped.
+      expect(probe.finish_executions).to eq(1)
+      expect(fake_chat.complete_count).to eq(2)
+      expect(fake_chat.tool_count_at_complete).to eq([2, 2])
+    end
+
+    it "does not inject the max-tool-calls limit message" do
+      probe.chat_completion(max_tool_calls: 25)
+
+      expect(fake_chat.instructions).not_to include(a_string_matching(/Maximum tool calls/))
+    end
+  end
+
+  context "regression: chat.complete returns a bare Halt" do
+    # Isolates the crash path (Halt has no #raw / #input_tokens) from the tool
+    # mechanics: the first completion returns a Halt directly.
+    let(:behavior) do
+      lambda do |_chat, n|
+        if n == 1
+          RubyLLM::Tool::Halt.new(Raix::FunctionToolAdapter::ToolCallsCapReached.new(3))
+        else
+          final_message("recovered")
+        end
+      end
+    end
+
+    it "does not raise and returns the final response" do
+      expect { @result = probe.chat_completion(max_tool_calls: 3) }.not_to raise_error
+      expect(@result).to eq("recovered")
+    end
+  end
+
+  context "when tool use stays under budget" do
+    # Two rounds of one call each, then the model returns text on its own -> no
+    # halt, normal Message path.
+    let(:behavior) do
+      lambda do |chat, n|
+        if n == 1
+          chat.tools[:do_work].call({ n: 1 })
+          chat.tools[:do_work].call({ n: 2 })
+          final_message("done under budget")
+        else
+          final_message("should not be reached")
+        end
+      end
+    end
+
+    it "runs every tool call and returns the model's own text without a second completion" do
+      response = probe.chat_completion(max_tool_calls: 5)
+
+      expect(response).to eq("done under budget")
+      expect(probe.work_executions).to eq(2)
+      expect(fake_chat.complete_count).to eq(1)
+      expect(fake_chat.instructions).not_to include(a_string_matching(/Maximum tool calls/))
+    end
+  end
+
+  context "when no tools are involved" do
+    let(:behavior) { ->(_chat, _n) { final_message("plain text answer") } }
+
+    it "returns the completion untouched" do
+      response = probe.chat_completion(available_tools: false)
+
+      expect(response).to eq("plain text answer")
+      expect(fake_chat.with_tool_count).to eq(0)
+      expect(fake_chat.complete_count).to eq(1)
+    end
+  end
+end

--- a/spec/raix/max_tool_calls_spec.rb
+++ b/spec/raix/max_tool_calls_spec.rb
@@ -17,7 +17,7 @@
 # with the chat and the 1-based completion number so a spec can run tools on the
 # first pass and return a final message on the forced second pass.
 class ScriptedRubyLLMChat
-  attr_reader :instructions, :tools, :with_tool_count, :complete_count, :tool_count_at_complete
+  attr_reader :instructions, :tools, :with_tool_count, :complete_count, :tool_count_at_complete, :requests
 
   def initialize(&behavior)
     @behavior = behavior
@@ -26,14 +26,25 @@ class ScriptedRubyLLMChat
     @with_tool_count = 0
     @complete_count = 0
     @tool_count_at_complete = []
+    # Per-completion capture: each entry records the instructions and messages
+    # applied to this chat since the previous completion, so a spec can inspect
+    # exactly what the forced final (tool-less) request was rebuilt from.
+    @requests = []
+    @current_instructions = []
+    @current_messages = []
   end
 
   def with_instructions(content, **)
     @instructions << content
+    @current_instructions << content
     self
   end
 
-  def add_message(**) = self
+  def add_message(**attrs)
+    @current_messages << attrs
+    self
+  end
+
   def reset_messages!; end
   def messages = []
   def with_temperature(_) = self
@@ -50,7 +61,11 @@ class ScriptedRubyLLMChat
   def complete(&)
     @complete_count += 1
     @tool_count_at_complete << @with_tool_count
-    @behavior.call(self, @complete_count)
+    result = @behavior.call(self, @complete_count)
+    @requests << { instructions: @current_instructions.dup, messages: @current_messages.dup }
+    @current_instructions = []
+    @current_messages = []
+    result
   end
 end
 
@@ -75,6 +90,24 @@ class ToolBudgetProbe
     @work_executions = 0
     @finish_executions = 0
     transcript << { user: "please work" }
+  end
+end
+
+# Exercises the documented `messages:` argument, which drives the request
+# without ever being written into the transcript.
+class ExplicitMessagesProbe
+  include Raix::ChatCompletion
+  include Raix::FunctionDispatch
+
+  attr_reader :work_executions
+
+  function :do_work, "does a unit of work", n: { type: "integer" } do |_args|
+    @work_executions += 1
+    "work result #{@work_executions}"
+  end
+
+  def initialize
+    @work_executions = 0
   end
 end
 
@@ -248,6 +281,52 @@ RSpec.describe Raix::ChatCompletion, "max_tool_calls enforcement under RubyLLM" 
       expect(response).to eq("plain text answer")
       expect(fake_chat.with_tool_count).to eq(0)
       expect(fake_chat.complete_count).to eq(1)
+    end
+  end
+
+  # Regression for the Codex finding: when chat_completion is driven by the
+  # documented `messages:` argument, those messages never enter the transcript.
+  # The forced final completion after a halt must still carry the caller's
+  # system/user prompt, not just the tool exchange recorded in the transcript.
+  context "when driven by an explicit messages: argument and a tool halts" do
+    subject(:probe) { ExplicitMessagesProbe.new }
+
+    let(:messages) do
+      [{ system: "You are a helpful assistant" }, { user: "Do some work then summarize" }]
+    end
+
+    let(:behavior) do
+      lambda do |chat, n|
+        if n == 1
+          halt = nil
+          10.times do
+            result = chat.tools[:do_work].call({ n: 1 })
+            if result.is_a?(RubyLLM::Tool::Halt)
+              halt = result
+              break
+            end
+          end
+          halt || raise("expected the wrapper to halt but it never did")
+        else
+          final_message("final answer from explicit messages")
+        end
+      end
+    end
+
+    it "replays the caller-provided system and user messages into the forced final completion" do
+      response = probe.chat_completion(messages:, max_tool_calls: 1)
+
+      expect(response).to eq("final answer from explicit messages")
+
+      final_request = fake_chat.requests.last
+      # The original system prompt survives into the tool-less final request...
+      expect(final_request[:instructions]).to include("You are a helpful assistant")
+      # ...as does the original user message (not just the tool exchange).
+      user_contents = final_request[:messages].select { |m| m[:role] == :user }.map { |m| m[:content] }
+      expect(user_contents).to include("Do some work then summarize")
+      # And the tool result still rides along so the model can use it.
+      tool_contents = final_request[:messages].select { |m| m[:role] == :tool }.map { |m| m[:content] }
+      expect(tool_contents).to include("work result 1")
     end
   end
 end


### PR DESCRIPTION
## The bug

Under the RubyLLM backend, `max_tool_calls` is dead code and agentic tool loops run unbounded.

`ChatCompletion#ruby_llm_request` registers tools on a `RubyLLM::Chat` and calls `chat.complete` / `chat.ask`. RubyLLM runs the whole tool loop *internally* — `complete → handle_tool_calls → complete` — and only returns once the model stops calling tools. So Raix's own counting loop (the `tool_calls = response.dig(...)` block in `chat_completion`) never sees a tool round: the response it gets back is always the post-loop final message. The counter never increments, the cap is never checked, and the loop never stops.

Two documented features are affected:

1. **`max_tool_calls`** ("Maximum number of tool calls before forcing a text response") is never enforced. Downstream this caused a real incident: ~90 unbounded tool rounds over ~79 minutes until the context died.
2. **`stop_tool_calls_and_respond!`** sets a flag that only the dead loop read, so it does nothing — RubyLLM keeps looping regardless.

## The fix

RubyLLM ships a halt mechanism: a tool's `execute` can return `RubyLLM::Tool#halt(message)`, and `Chat#handle_tool_calls` returns `halt_result || complete(&)` — a `Halt` stops the auto-continuation and `chat.complete` returns the `Halt` object.

- **Enforce the budget inside the generated tool wrapper** (`FunctionToolAdapter`). Each invocation increments a per-completion counter on the Raix instance; once it exceeds `max_tool_calls`, the wrapper refuses to run the underlying function and returns `halt(...)`. Enforcement is **per call** on purpose: one model response can pack several parallel tool calls, and RubyLLM executes every call in a round even after one halts, so each wrapper checks the shared counter independently. The wrapper also halts (wrapping the real result) when `stop_tool_calls_and_respond!` has set its flag after a successful execution.

- **Handle the Halt in `ChatCompletion`.** `chat.complete`/`#ask` returns a `RubyLLM::Tool::Halt` (not a `Message`, so `#raw`/`#input_tokens` would crash) — `ruby_llm_request` now detects it and hands it back. On a cap trip `chat_completion` appends the existing `"Maximum tool calls (N) exceeded. Please provide a final response…"` system message; for both cap and stop-requested halts it then issues **one** final completion with no tools (and drops `tool_choice`, since forcing tool use with no tools registered is a provider error) and returns its text through the normal path. The final completion is rebuilt from the transcript, which already carries every executed tool call/result pair — and a *refused* call leaves no dangling assistant `tool_call` behind, since `FunctionDispatch` only appends the call/result pair on execution.

- **Fix a latent tool-call replay bug.** Replaying transcript assistant tool-call messages into a fresh `RubyLLM::Chat` raised `NoMethodError: undefined method 'id' for nil`: Raix stores tool calls in OpenAI's array-of-hashes shape, but RubyLLM's providers expect `{ id => RubyLLM::ToolCall }`. That path was unreachable before this change; the forced final completion now exercises it, so `ruby_llm_request` translates the shape.

## Tests

New `spec/raix/max_tool_calls_spec.rb` (8 examples) covers: the (N+1)th call refused with the underlying function not executed; a single response packing multiple parallel calls unable to exceed the cap; forced final completion without tools + limit message present; `stop_tool_calls_and_respond!` halting and forcing a final text response; a regression guarding the `Halt` crash; and that under-budget tool runs and plain completions are unaffected. The pre-existing VCR spec `respects max_tool_calls parameter` now genuinely exercises the cap (it passed on `main` only because the cap was dead) and still passes. Full suite green (121 examples, 0 failures, 1 pre-existing pending), RuboCop clean. Gemspec floor stays `ruby_llm ~> 1.9` — the halt and `ToolCall` APIs relied on are all present at 1.9.0.

## Design note

On the forced final completion, the appended limit system message goes through `chat.with_instructions`, whose default *replaces* rather than appends — so the original system prompt is dropped for that one final call. This matches the prior (dead) code path's intent and keeps the diff minimal (the transcript still carries the user question and all tool results), but happy to preserve the original prompt there if you'd rather.

## Downstream

This lets zarpay/nexus delete the `RubyLLMToolLoopCap` / `RaixMaxToolCallsBridge` monkey-patch shim it shipped to cap the loop (context: https://github.com/zarpay/nexus/pull/409, private repo — the shim wraps every generated tool to count calls and short-circuit once a per-request cap is hit, exactly what this PR now does upstream).

---
*Nexy (Sollers Purgator)* · [Agora profile](https://agora.internal.zarhq.dev/admin/legates/58)
